### PR TITLE
Adding basic watch later stats

### DIFF
--- a/YoutubeWebserver.py
+++ b/YoutubeWebserver.py
@@ -96,6 +96,10 @@ def sort():
             sortLog.info("Watchlater stored in DB for stats!")
             pt.setQuotaUsed(inDB, quota, 1)
             sortLog.info(f"Used Quota set! Total accrude: {quota}")
+            datetime = dt.now().strftime('%Y-%m-%d %H:%M:%S')
+            pt.WatchLaterStats(youtubeWatchLater, datetime)
+            pt.WatchLaterCreatorStats(youtubeWatchLater, datetime, youtube) #This can use quota
+            sortLog.info("Watch later stats stored")
             pt.CloseDBconnnection()
             sortLog.info(f"Database connection closed!")
             msg = "& Stored!"

--- a/YoutubeWebserver.py
+++ b/YoutubeWebserver.py
@@ -102,7 +102,7 @@ def sort():
             sortLog.info("Watch later stats stored")
             pt.CloseDBconnnection()
             sortLog.info(f"Database connection closed!")
-            msg = "& Stored!"
+            msg += " & Stored!"
         except Exception:
             if msg != "":
                 msg += " & "

--- a/pywertube.py
+++ b/pywertube.py
@@ -239,9 +239,9 @@ def storeWatchLaterDB(watchlater):
 def CloseDBconnnection():
     gLogger.debug("Entering...")
     gLogger.debug("Closing DB connection...")
+    global gDBconn
     gDBconn.close()
     gLogger.debug("Clearing Global DB connection variable...")
-    global gDBconn
     gDBconn = None
     gLogger.debug("Cleared! Leaving...")
 
@@ -688,7 +688,7 @@ def sortSequentialVideo(watchLaterList):
     return watchLaterList
 
 def sortWatchLater(watchLaterList, creatorDict, keywordDict, numSerKeywords, serKeywords, videoIDFollowUpList, sequentialCreators):
-    #WatchLaterList structured as (position on yt, playlist id for yt, video id for yt, duration in seconds, creator, published time in unix time, video title)
+    #WatchLaterList structured as (0-position on yt, 1-playlist id for yt, 2-video id for yt, 3-duration in seconds, 4-creator, 5-published time in unix time, 6-video title)
     gLogger.debug("Entering...")
     gLogger.debug("Initalizing variables...")
     videoCountThreshold = 50 #Number of items in list to determine priority limit
@@ -709,7 +709,10 @@ def sortWatchLater(watchLaterList, creatorDict, keywordDict, numSerKeywords, ser
     gLogger.debug("Getting Priority list...")
     priorityWatchLater, workingWatchLater = getPriorityVideos(watchLaterList, creatorDict, keywordDict, priorityThreshold, durationThreshold)
     gLogger.debug("Priority list obtained! Getting Follow-up list...")
-    followUpWatchLater = getFollowUpVideos(workingWatchLater, videoIDFollowUpList)
+    if videoIDFollowUpList:
+        followUpWatchLater = getFollowUpVideos(workingWatchLater, videoIDFollowUpList)
+    else:
+        followUpWatchLater = []
     gLogger.debug("Follow-up list obtained! Getting Serialized list...")
     seriesWatchLater, workingWatchLater = getSerializedVideos(workingWatchLater, numSerKeywords, serKeywords)
     gLogger.debug("Serialized list obtained! Getting Sequential list...")


### PR DESCRIPTION
### Added stats for:
##### Main Watch Later Stats
- Total number of videos in watch later
- Total duration length of watch later
- Average length of video in watch later queue
- Median length of video in watch later queue
- Standard deviation of watch later queue
- Variance of watch later queue
- Total number of creators in watch later queue

##### Watch Later Creator Stats
- Number of videos by creator
- Amount of time creator takes up in watch later
- Oldest video by creator
- Longest video by creator
- Average Age of creator video
- Percentage of queue taken up by creator (In frequency)
- Percentage of queue taken up by creator (In duration/watch time)
